### PR TITLE
refactor: restructure linux builds and add arm64 support

### DIFF
--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -1,18 +1,18 @@
 ---
-name: build flang for linux-static (x86_64)
+name: build flang for linux (arm64)
 
 on:
   push:
     branches: [master]
     paths:
-      - '.github/workflows/build-linux-static-x86_64.yml'
+      - '.github/workflows/build-linux-arm64.yml'
       - 'docker/llvm-musl-builder/**'
       - 'cmake/CMakePresets.json'
       - 'versions.env'
   pull_request:
     branches: [master]
     paths:
-      - '.github/workflows/build-linux-static-x86_64.yml'
+      - '.github/workflows/build-linux-arm64.yml'
       - 'docker/llvm-musl-builder/**'
       - 'cmake/CMakePresets.json'
       - 'versions.env'
@@ -20,12 +20,12 @@ on:
   workflow_call:
 
 jobs:
-  build-linux-static-x86_64:
-    runs-on: ubuntu-latest
+  build-linux-arm64:
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 480
     env:
       SCCACHE_GHA_ENABLED: "true"
-      TARGET_TRIPLE: "x86_64-unknown-linux-gnu-static"
+      TARGET_TRIPLE: "aarch64-unknown-linux-gnu"
 
     steps:
       - name: Checkout repository
@@ -119,7 +119,7 @@ jobs:
 
               echo "=== Configuring CMake (Static Build) ==="
               cp /work/cmake/CMakePresets.json /work/llvm-project/llvm/
-              cmake --preset linux-static-x86_64 -S /work/llvm-project/llvm -B /work/build \
+              cmake --preset linux-static-arm64 -S /work/llvm-project/llvm -B /work/build \
                     -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                     -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 

--- a/.github/workflows/build-linux-x86_64.yml
+++ b/.github/workflows/build-linux-x86_64.yml
@@ -6,12 +6,14 @@ on:
     branches: [master]
     paths:
       - '.github/workflows/build-linux-x86_64.yml'
+      - 'docker/llvm-musl-builder/**'
       - 'cmake/CMakePresets.json'
       - 'versions.env'
   pull_request:
     branches: [master]
     paths:
       - '.github/workflows/build-linux-x86_64.yml'
+      - 'docker/llvm-musl-builder/**'
       - 'cmake/CMakePresets.json'
       - 'versions.env'
   workflow_dispatch:
@@ -20,11 +22,9 @@ on:
 jobs:
   build-linux-x86_64:
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 480
     env:
       SCCACHE_GHA_ENABLED: "true"
-      CMAKE_C_COMPILER_LAUNCHER: "sccache"
-      CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
       TARGET_TRIPLE: "x86_64-unknown-linux-gnu"
 
     steps:
@@ -36,6 +36,7 @@ jobs:
           source versions.env
           echo "LLVM_VERSION=$LLVM_VERSION" >> $GITHUB_ENV
           echo "SCCACHE_VERSION=$SCCACHE_VERSION" >> $GITHUB_ENV
+          echo "NINJA_VERSION=$NINJA_VERSION" >> $GITHUB_ENV
 
       - name: Show system information
         run: |
@@ -50,15 +51,17 @@ jobs:
           echo "=== Disk Information ==="
           df -h
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
-
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: ${{ env.SCCACHE_VERSION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: |
+          docker build -t llvm-musl-builder:latest -f docker/llvm-musl-builder/Dockerfile .
 
       - name: Restore LLVM Source Cache
         id: cache-llvm
@@ -79,30 +82,64 @@ jobs:
           path: llvm-project
           key: llvm-source-${{ env.LLVM_VERSION }}
 
-      - name: Configure CMake
+      - name: Configure, Build and Install
+        env:
+          NINJA_VERSION: ${{ env.NINJA_VERSION }}
         run: |
-          cp cmake/CMakePresets.json llvm-project/llvm/
-          cmake --preset linux-x86_64 -S llvm-project/llvm -B build \
-                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          docker run --rm \
+            -v "${PWD}:/work" \
+            -v "${HOME}/.cache/sccache:/cache/sccache" \
+            -e SCCACHE_DIR=/cache/sccache \
+            -e ACTIONS_CACHE_SERVICE_V2="${ACTIONS_CACHE_SERVICE_V2}" \
+            -e ACTIONS_RESULTS_URL="${ACTIONS_RESULTS_URL}" \
+            -e ACTIONS_RUNTIME_TOKEN="${ACTIONS_RUNTIME_TOKEN}" \
+            -e SCCACHE_GHA_ENABLED="true" \
+            -e NINJA_VERSION="${NINJA_VERSION}" \
+            llvm-musl-builder:latest \
+            /bin/bash -c '
+              set -e
 
-      - name: Build
-        run: |
-          echo "=== Building ==="
-          ninja -C build runtimes
+              export CMAKE_C_COMPILER_LAUNCHER="sccache"
+              export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
 
-      - name: Install
-        run: |
-          echo "=== Installing ==="
-          ninja -C build runtimes/install
-          ninja -C build tools/flang/tools/install
-          ninja -C build tools/llvm-nm/install
-          ninja -C build tools/llvm-ar/install
+              echo "=== Installing Ninja ${NINJA_VERSION} ==="
+              cd /tmp
+              wget -q https://github.com/ninja-build/ninja/archive/refs/tags/v${NINJA_VERSION}.tar.gz
+              tar xzf v${NINJA_VERSION}.tar.gz
+              cd ninja-${NINJA_VERSION}
+              cmake -B build \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DBUILD_TESTING=OFF
+              cmake --build build -j$(nproc)
+              cp build/ninja /usr/local/bin/
+              ninja --version
+              cd /work
 
-      - name: Package binaries
-        run: |
-          mv install flang+llvm-${{ env.LLVM_VERSION }}
-          tar -czf flang+llvm-${{ env.LLVM_VERSION }}-${{ env.TARGET_TRIPLE }}.tar.gz flang+llvm-${{ env.LLVM_VERSION }}
+              mkdir -p /work/build /work/install
+
+              echo "=== Configuring CMake (Static Build) ==="
+              cp /work/cmake/CMakePresets.json /work/llvm-project/llvm/
+              cmake --preset linux-static-x86_64 -S /work/llvm-project/llvm -B /work/build \
+                    -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+                    -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+
+              echo "=== Building ==="
+              ninja -C /work/build runtimes
+
+              echo "=== Installing ==="
+              ninja -C /work/build runtimes/install
+              ninja -C /work/build tools/flang/tools/install
+              ninja -C /work/build tools/llvm-nm/install
+              ninja -C /work/build tools/llvm-ar/install
+
+              echo "=== sccache Statistics ==="
+              sccache --show-stats
+
+              echo "=== Creating tarball ==="
+              cd /work
+              mv install flang+llvm-${{ env.LLVM_VERSION }}
+              tar czf flang+llvm-${{ env.LLVM_VERSION }}-${{ env.TARGET_TRIPLE }}.tar.gz flang+llvm-${{ env.LLVM_VERSION }}
+            '
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
     if: ${{ github.event.inputs.rebuild == 'true' }}
     uses: ./.github/workflows/build-linux-x86_64.yml
 
-  build-linux-static-x86_64:
+  build-linux-arm64:
     if: ${{ github.event.inputs.rebuild == 'true' }}
-    uses: ./.github/workflows/build-linux-static-x86_64.yml
+    uses: ./.github/workflows/build-linux-arm64.yml
 
   build-macos-x86_64:
     if: ${{ github.event.inputs.rebuild == 'true' }}
@@ -92,7 +92,7 @@ jobs:
           names=( \
             "flang+llvm-${VERSION}-x86_64-pc-windows-msvc" \
             "flang+llvm-${VERSION}-x86_64-unknown-linux-gnu" \
-            "flang+llvm-${VERSION}-x86_64-unknown-linux-gnu-static" \
+            "flang+llvm-${VERSION}-aarch64-unknown-linux-gnu" \
             "flang+llvm-${VERSION}-x86_64-apple-darwin" \
             "flang+llvm-${VERSION}-arm64-apple-darwin" \
           )
@@ -144,6 +144,6 @@ jobs:
           files: |
             ./artifacts/flang+llvm-${{ steps.vars.outputs.VERSION }}-x86_64-pc-windows-msvc.zip
             ./artifacts/flang+llvm-${{ steps.vars.outputs.VERSION }}-x86_64-unknown-linux-gnu.tar.gz
-            ./artifacts/flang+llvm-${{ steps.vars.outputs.VERSION }}-x86_64-unknown-linux-gnu-static.tar.gz
+            ./artifacts/flang+llvm-${{ steps.vars.outputs.VERSION }}-aarch64-unknown-linux-gnu.tar.gz
             ./artifacts/flang+llvm-${{ steps.vars.outputs.VERSION }}-x86_64-apple-darwin.tar.gz
             ./artifacts/flang+llvm-${{ steps.vars.outputs.VERSION }}-arm64-apple-darwin.tar.gz

--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -281,6 +281,14 @@
       }
     },
     {
+      "name": "linux-static-arm64",
+      "displayName": "Linux ARM64 Static (musl)",
+      "inherits": "linux-static-x86_64",
+      "cacheVariables": {
+        "LLVM_DEFAULT_TARGET_TRIPLE": "aarch64-unknown-linux-gnu"
+      }
+    },
+    {
       "name": "macos-x86_64",
       "displayName": "macOS x86_64 (Intel)",
       "inherits": "base",


### PR DESCRIPTION
## Summary
- Retire dynamic linux build, use static (musl) builds only
- Rename linux-static-x86_64 to linux-x86_64
- Add native arm64 linux build (ubuntu-24.04-arm64 runner)
- Update release.yml for new artifact names

Closes #4